### PR TITLE
feat(#39): heachi notify

### DIFF
--- a/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
+++ b/heachi-core/auth-api/src/main/java/com/heachi/auth/api/controller/auth/AuthController.java
@@ -11,7 +11,11 @@ import com.heachi.mysql.define.user.constant.UserPlatformType;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -54,5 +58,11 @@ public class AuthController {
             @PathVariable("platformType") UserPlatformType platformType,
             @RequestBody AuthRegisterRequest request) {
         return JsonResult.successOf();
+    }
+
+    @GetMapping("/info")
+    public JsonResult<?> userInfo(@AuthenticationPrincipal UserDetails user) {
+
+        return JsonResult.successOf(user);
     }
 }

--- a/heachi-domain-mongo/src/main/java/com/heachi/mongo/define/notify/Notify.java
+++ b/heachi-domain-mongo/src/main/java/com/heachi/mongo/define/notify/Notify.java
@@ -3,6 +3,7 @@ package com.heachi.mongo.define.notify;
 import com.heachi.mongo.define.notify.constant.NotifyType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 @Getter
+@ToString
 @Document(collection = "notify")
 public class Notify {
     @Id

--- a/heachi-notify/build.gradle
+++ b/heachi-notify/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':heachi-domain-mongo')
     implementation project(':heachi-support:common')
     implementation project(':heachi-support:logging')
+    implementation project(':heachi-support:external-clients')
 
     implementation "org.springframework.boot:spring-boot-starter-webflux"
     testImplementation "io.projectreactor:reactor-test"

--- a/heachi-notify/src/main/java/com/heachi/notify/api/controller/NotifyController.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/controller/NotifyController.java
@@ -1,14 +1,18 @@
 package com.heachi.notify.api.controller;
 
 import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.clients.auth.AuthClients;
 import com.heachi.notify.api.controller.request.NotifyRegistRequest;
 import com.heachi.notify.api.service.request.NotifyServiceRegistRequest;
 import com.heachi.notify.api.service.response.NotifyServiceReceiverResponse;
 import com.heachi.notify.api.service.NotifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @RestController
 @RequestMapping("/notify")
@@ -16,11 +20,21 @@ import reactor.core.publisher.Flux;
 public class NotifyController {
 
     private final NotifyService notifyService;
+    private final AuthClients authClients;
 
-    @GetMapping(value = "/{receiverId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<NotifyServiceReceiverResponse> receive(@PathVariable("receiverId") String receiverId) {
+    @GetMapping(value = "/", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<JsonResult> receive(@RequestHeader(value = "Authorization") String headers) {
+        System.out.println("headers = " + headers.substring(7));
 
-        return notifyService.receive(receiverId, 30);
+        return authClients.getUserInfo(headers)
+                .flatMapMany(userInfoResponseJsonResult -> {
+                    if (userInfoResponseJsonResult.getResObj() == null) {
+                        return Flux.just(JsonResult.failOf());
+                    }
+
+                    return notifyService.receive(userInfoResponseJsonResult.getResObj().getName());
+                })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     @PostMapping("/")

--- a/heachi-notify/src/main/java/com/heachi/notify/api/controller/NotifyController.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/controller/NotifyController.java
@@ -1,18 +1,23 @@
 package com.heachi.notify.api.controller;
 
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.oauth.OAuthException;
 import com.heachi.admin.common.response.JsonResult;
 import com.heachi.external.clients.auth.AuthClients;
 import com.heachi.notify.api.controller.request.NotifyRegistRequest;
-import com.heachi.notify.api.service.request.NotifyServiceRegistRequest;
-import com.heachi.notify.api.service.response.NotifyServiceReceiverResponse;
-import com.heachi.notify.api.service.NotifyService;
+import com.heachi.notify.api.service.auth.AuthService;
+import com.heachi.notify.api.service.notify.request.NotifyServiceRegistRequest;
+import com.heachi.notify.api.service.notify.NotifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+
+import java.net.ConnectException;
+import java.time.Duration;
 
 @RestController
 @RequestMapping("/notify")
@@ -20,26 +25,24 @@ import reactor.core.scheduler.Schedulers;
 public class NotifyController {
 
     private final NotifyService notifyService;
-    private final AuthClients authClients;
+    private final AuthService authService;
 
     @GetMapping(value = "/", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<JsonResult> receive(@RequestHeader(value = "Authorization") String headers) {
-        System.out.println("headers = " + headers.substring(7));
+    public Flux<JsonResult> receive(@RequestHeader(value = "Authorization", required = false, defaultValue = "token") String headers) {
 
-        return authClients.getUserInfo(headers)
-                .flatMapMany(userInfoResponseJsonResult -> {
-                    if (userInfoResponseJsonResult.getResObj() == null) {
-                        return Flux.just(JsonResult.failOf());
-                    }
-
-                    return notifyService.receive(userInfoResponseJsonResult.getResObj().getName());
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+        return authService.getUserId(headers)
+                .flatMapMany(sendUserId -> notifyService.receive(sendUserId))
+                .subscribeOn(Schedulers.boundedElastic());  // publisher의 스케줄러를 boundedElastic으로 변경
     }
 
     @PostMapping("/")
-    public JsonResult registNotify(@RequestBody NotifyRegistRequest request) {
-        notifyService.registNotify(NotifyServiceRegistRequest.of(request));
-        return JsonResult.successOf();
+    public Mono<JsonResult> registNotify(
+            @RequestHeader(value = "Authorization", required = false, defaultValue = "token") String headers,
+            @RequestBody NotifyRegistRequest request) {
+        return authService.getUserId(headers)
+                .flatMap(sendUserId -> notifyService
+                        .registNotify(NotifyServiceRegistRequest.of(request, sendUserId))
+                        .thenReturn(JsonResult.successOf()))
+                .subscribeOn(Schedulers.boundedElastic());  // publisher의 스케줄러를 boundedElastic으로 변경
     }
 }

--- a/heachi-notify/src/main/java/com/heachi/notify/api/controller/request/NotifyRegistRequest.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/controller/request/NotifyRegistRequest.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class NotifyRegistRequest {
-    private String sendUserId;                                          // 알림을 보낸 유저 아이디
     private List<String> receiveUserIds = new ArrayList<>();            // 알림을 받는 아이디
     private NotifyType type;                                            // 알림 종류
     private String message;                                             // 알림 내용

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/NotifyService.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/NotifyService.java
@@ -19,12 +19,13 @@ public class NotifyService {
 
     private final NotifyRepository notifyRepository;
 
-    public Flux<NotifyServiceReceiverResponse> receive(String receiverId, Integer timeoutSeconds) {
+    public Flux<JsonResult> receive(String receiverId) {
         return notifyRepository.findByReceiveUserIds(receiverId)
-                .mapNotNull(NotifyServiceReceiverResponse::of)
-                .doOnNext(response -> System.out.println("response = " + response))
-                .timeout(Duration.ofSeconds(timeoutSeconds), Flux.just())
-                .subscribeOn(Schedulers.boundedElastic());
+                .flatMap(notify -> {
+                    NotifyServiceReceiverResponse nsrr = NotifyServiceReceiverResponse.of(notify);
+
+                    return Flux.just(JsonResult.successOf(nsrr));
+                });
     }
 
     public void registNotify(NotifyServiceRegistRequest request) {

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/auth/AuthService.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/auth/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
     public Mono<String> getUserId(String token) {
 
         return authClients.getUserInfo(token)
-                .onErrorMap(WebClientRequestException.class, t -> new AuthException(ExceptionMessage.AUTH_SERVER_NOT_RESPOND))
+                .onErrorMap(t -> new AuthException(ExceptionMessage.AUTH_SERVER_NOT_RESPOND))
                 .map(userInfoResponseJsonResult -> {
                     if (userInfoResponseJsonResult.getResObj() == null) {
                         throw new JwtException(ExceptionMessage.JWT_USER_NOT_FOUND);

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/auth/AuthService.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/auth/AuthService.java
@@ -1,0 +1,37 @@
+package com.heachi.notify.api.service.auth;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.auth.AuthException;
+import com.heachi.admin.common.exception.jwt.JwtException;
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.clients.auth.AuthClients;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+
+import java.net.ConnectException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthClients authClients;
+
+    // 토큰으로 유저 아이디 가져오기
+    public Mono<String> getUserId(String token) {
+
+        return authClients.getUserInfo(token)
+                .onErrorMap(WebClientRequestException.class, t -> new AuthException(ExceptionMessage.AUTH_SERVER_NOT_RESPOND))
+                .map(userInfoResponseJsonResult -> {
+                    if (userInfoResponseJsonResult.getResObj() == null) {
+                        throw new JwtException(ExceptionMessage.JWT_USER_NOT_FOUND);
+                    }
+
+                    return userInfoResponseJsonResult.getResObj().getPlatformId();
+                });
+    }
+}

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/NotifyService.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/NotifyService.java
@@ -1,17 +1,18 @@
-package com.heachi.notify.api.service;
+package com.heachi.notify.api.service.notify;
 
 import com.heachi.admin.common.response.JsonResult;
 import com.heachi.mongo.define.notify.Notify;
 import com.heachi.mongo.define.notify.repository.NotifyRepository;
-import com.heachi.notify.api.controller.request.NotifyRegistRequest;
-import com.heachi.notify.api.service.request.NotifyServiceRegistRequest;
-import com.heachi.notify.api.service.response.NotifyServiceReceiverResponse;
+import com.heachi.notify.api.service.notify.request.NotifyServiceRegistRequest;
+import com.heachi.notify.api.service.notify.response.NotifyServiceReceiverResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +26,12 @@ public class NotifyService {
                     NotifyServiceReceiverResponse nsrr = NotifyServiceReceiverResponse.of(notify);
 
                     return Flux.just(JsonResult.successOf(nsrr));
-                });
+                })
+                .timeout(Duration.ofSeconds(30))
+                .onErrorReturn(TimeoutException.class, JsonResult.failOf("Timeout"));   // 30초가 지나면 타임아웃
     }
 
-    public void registNotify(NotifyServiceRegistRequest request) {
-        notifyRepository.save(request.toEntity()).subscribe();
+    public Mono<Notify> registNotify(NotifyServiceRegistRequest request) {
+        return notifyRepository.save(request.toEntity());
     }
 }

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/request/NotifyServiceRegistRequest.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/request/NotifyServiceRegistRequest.java
@@ -1,4 +1,4 @@
-package com.heachi.notify.api.service.request;
+package com.heachi.notify.api.service.notify.request;
 
 import com.heachi.mongo.define.notify.Notify;
 import com.heachi.mongo.define.notify.constant.NotifyType;
@@ -32,9 +32,9 @@ public class NotifyServiceRegistRequest {
         this.url = url;
     }
 
-    public static NotifyServiceRegistRequest of(NotifyRegistRequest request) {
+    public static NotifyServiceRegistRequest of(NotifyRegistRequest request, String sendUserId) {
         return NotifyServiceRegistRequest.builder()
-                .sendUserId(request.getSendUserId())
+                .sendUserId(sendUserId)
                 .receiveUserIds(request.getReceiveUserIds())
                 .type(request.getType())
                 .message(request.getMessage())

--- a/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/response/NotifyServiceReceiverResponse.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/api/service/notify/response/NotifyServiceReceiverResponse.java
@@ -1,15 +1,17 @@
-package com.heachi.notify.api.service.response;
+package com.heachi.notify.api.service.notify.response;
 
 import com.heachi.admin.common.utils.DateDistance;
 import com.heachi.mongo.define.notify.Notify;
 import com.heachi.mongo.define.notify.constant.NotifyType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.*;
 
 @Getter
+@ToString
 public class NotifyServiceReceiverResponse {
     private String sendUserId;                                          // 알림을 보낸 유저 아이디
     private List<String> receiveUserIds = new ArrayList<>();            // 알림을 받는 아이디

--- a/heachi-notify/src/main/java/com/heachi/notify/config/advice/GlobalExceptionHandler.java
+++ b/heachi-notify/src/main/java/com/heachi/notify/config/advice/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.heachi.notify.config.advice;
+
+import com.heachi.admin.common.exception.HeachiException;
+import com.heachi.admin.common.response.JsonResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import reactor.core.publisher.Mono;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public JsonResult exception(Exception e) {
+
+        return JsonResult.failOf(e.getMessage());
+    }
+}

--- a/heachi-notify/src/test/java/com/heachi/notify/api/service/NotifyServiceTest.java
+++ b/heachi-notify/src/test/java/com/heachi/notify/api/service/NotifyServiceTest.java
@@ -1,24 +1,34 @@
 package com.heachi.notify.api.service;
 
+import com.heachi.admin.common.response.JsonResult;
 import com.heachi.mongo.define.notify.Notify;
+import com.heachi.mongo.define.notify.constant.NotifyType;
 import com.heachi.mongo.define.notify.repository.NotifyRepository;
 import com.heachi.notify.TestConfig;
-import com.heachi.notify.api.service.response.NotifyServiceReceiverResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.heachi.notify.api.service.notify.NotifyService;
+import com.heachi.notify.api.service.notify.response.NotifyServiceReceiverResponse;
+import org.junit.jupiter.api.*;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
+import reactor.test.scheduler.VirtualTimeScheduler;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @SpringBootTest
 class NotifyServiceTest extends TestConfig {
@@ -29,36 +39,84 @@ class NotifyServiceTest extends TestConfig {
     @Autowired
     private NotifyService notifyService;
 
-    @AfterEach
-    void tearDown() {
-        notifyRepository.deleteAll();
+    @BeforeEach
+    void setUp() {
+        notifyRepository.deleteAll().block();
     }
 
     @Test
-    @Disabled
-    @DisplayName("구독 도중 객체가 추가되었을때 값이 반영이 되어있어야한다.")
-    void addNotifyWhenSubscribeOn() {
+    @DisplayName("구독하면, 30초가 커넥션이 유지되고, 30초가 지나면 커넥션은 끊긴다.")
+    void connection30secondsWhenClientSubscribe() {
         // given
-//        Notify notify1 = Notify.builder()
-//                .sendUserId("홍찬희1")
-//                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
-//                .build();
-//        Notify notify2 = Notify.builder()
-//                .sendUserId("홍찬희1")
-//                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
-//                .build();
-//
-//        // when
-//        Flux<NotifyServiceReceiverResponse> responseFlux = notifyService.receive("ghdcksgml1", 1);
-//        Flux<Notify> notifyFlux = notifyRepository.saveAll(List.of(notify1, notify2));
-//
-//        // then
-//        StepVerifier.create(responseFlux)
-//                .expectNextMatches(response -> {
-//                    assertThat(response.getSendUserId()).isEqualTo("홍찬희1");
-//
-//                    return true;
-//                })
-//                .verifyComplete();
+
+        // when
+        StepVerifier.withVirtualTime(() -> notifyService.receive("2954438047"))
+                // then
+                .expectSubscription()               // 구독이 시작되고 나서
+                .thenAwait(Duration.ofSeconds(30))  // 30초간 아무런 응답이 없으면
+                .expectNextMatches(jsonResult -> {  // 에러를 뱉음
+                    assertThat(jsonResult.getResCode()).isEqualTo(400);
+                    assertThat(jsonResult.getResMsg()).isEqualTo("Timeout");
+
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("구독 도중 객체가 추가되었을때 값이 곧바로 반영된다.")
+    void addNotifyWhenSubscribeOn() throws InterruptedException {
+        // given
+        Notify notify1 = Notify.builder()
+                .sendUserId("ghdcksgml1")
+                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
+                .type(NotifyType.NOTE)
+                .createdTime(LocalDateTime.now())
+                .checkedTime(new HashMap<>())
+                .checked(new HashSet<>())
+                .build();
+        Notify notify2 = Notify.builder()
+                .sendUserId("ghdcksgml2")
+                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
+                .type(NotifyType.NOTE)
+                .createdTime(LocalDateTime.now())
+                .checkedTime(new HashMap<>())
+                .checked(new HashSet<>())
+                .build();
+        Notify notify3 = Notify.builder()
+                .sendUserId("ghdcksgml3")
+                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
+                .type(NotifyType.NOTE)
+                .createdTime(LocalDateTime.now())
+                .checkedTime(new HashMap<>())
+                .checked(new HashSet<>())
+                .build();
+
+        notifyRepository.save(notify1).block(); // 매칭되는 아이디가 없으면 Flux가 실행이 안되기 때문에 임의의 데이터를 저장.
+
+        // when
+        StepVerifier.withVirtualTime(() -> {
+                    Flux<Notify> event = Mono.delay(Duration.ofSeconds(2)).thenMany(notifyRepository.saveAll(List.of(notify2, notify3)));
+                    Flux<JsonResult> flux = notifyService.receive("ghdcksgml1");
+
+                    return Flux.merge(event, flux).log();
+                })
+                // then
+                .expectSubscription()
+                .expectNextCount(1)                     // 임의의 데이터 1개
+                .expectNoEvent(Duration.ofSeconds(2))   // 2초뒤 2개 저장됨
+                .expectNextCount(4)                     // repository.save()가 2번 호출됨, notifyService.receive()에서 2개의 데이터를 바로 받음
+                .expectNoEvent(Duration.ofSeconds(30))  // idle 상태가 30초 동안 지속되면
+                .expectNextMatches(o -> {
+                    if (o instanceof JsonResult) {
+                        assertThat(((JsonResult<?>) o).getResCode()).isEqualTo(400);
+
+                        return true;
+                    }
+                    return false;
+                })
+                .verifyComplete();
+
+
     }
 }

--- a/heachi-notify/src/test/java/com/heachi/notify/api/service/NotifyServiceTest.java
+++ b/heachi-notify/src/test/java/com/heachi/notify/api/service/NotifyServiceTest.java
@@ -39,26 +39,26 @@ class NotifyServiceTest extends TestConfig {
     @DisplayName("구독 도중 객체가 추가되었을때 값이 반영이 되어있어야한다.")
     void addNotifyWhenSubscribeOn() {
         // given
-        Notify notify1 = Notify.builder()
-                .sendUserId("홍찬희1")
-                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
-                .build();
-        Notify notify2 = Notify.builder()
-                .sendUserId("홍찬희1")
-                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
-                .build();
-
-        // when
-        Flux<NotifyServiceReceiverResponse> responseFlux = notifyService.receive("ghdcksgml1", 1);
-        Flux<Notify> notifyFlux = notifyRepository.saveAll(List.of(notify1, notify2));
-
-        // then
-        StepVerifier.create(responseFlux)
-                .expectNextMatches(response -> {
-                    assertThat(response.getSendUserId()).isEqualTo("홍찬희1");
-
-                    return true;
-                })
-                .verifyComplete();
+//        Notify notify1 = Notify.builder()
+//                .sendUserId("홍찬희1")
+//                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
+//                .build();
+//        Notify notify2 = Notify.builder()
+//                .sendUserId("홍찬희1")
+//                .receiveUserIds(List.of("ghdcksgml1", "ghdcksgml2", "ghdcksgml3"))
+//                .build();
+//
+//        // when
+//        Flux<NotifyServiceReceiverResponse> responseFlux = notifyService.receive("ghdcksgml1", 1);
+//        Flux<Notify> notifyFlux = notifyRepository.saveAll(List.of(notify1, notify2));
+//
+//        // then
+//        StepVerifier.create(responseFlux)
+//                .expectNextMatches(response -> {
+//                    assertThat(response.getSendUserId()).isEqualTo("홍찬희1");
+//
+//                    return true;
+//                })
+//                .verifyComplete();
     }
 }

--- a/heachi-notify/src/test/java/com/heachi/notify/api/service/auth/AuthServiceTest.java
+++ b/heachi-notify/src/test/java/com/heachi/notify/api/service/auth/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package com.heachi.notify.api.service.auth;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.jwt.JwtException;
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.clients.auth.AuthClients;
+import com.heachi.external.clients.auth.response.UserInfoResponse;
+import com.heachi.notify.TestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AuthServiceTest extends TestConfig {
+
+    private AuthService authService;
+    private MockAuthClients mockAuthClients;
+
+    @BeforeEach
+    void setUp() {
+        mockAuthClients = new MockAuthClients();
+        authService = new AuthService(mockAuthClients);
+    }
+
+    @Test
+    @DisplayName("사용자가 이상한 토큰으로 사용자 인증을 요구하면 에러를 뱉는다.")
+    void malformedTokenWhenAuthServerRequest() {
+        // given
+        String malformedToken = "malformedToken";
+
+        Mono<String> mono = authService.getUserId(malformedToken).log();
+
+        // when
+        StepVerifier.create(mono)
+                // then
+                .expectSubscription()
+                .expectError()
+                .verify();
+    }
+
+    @Test
+    @DisplayName("올바른 토큰을 보냈을때 유저 정보를 리턴한다.")
+    void getUserInfoSuccess() {
+        // given
+        String token = "successToken";
+
+        Mono<String> mono = authService.getUserId(token).log();
+
+        // when
+        StepVerifier.create(mono)
+                // then
+                .expectSubscription()
+                .expectNextMatches(userId -> {
+                    assertThat(userId).isEqualTo("id");
+
+                    return true;
+                })
+                .verifyComplete();
+    }
+
+    private class MockAuthClients implements AuthClients {
+
+        @Override
+        public Mono<JsonResult<UserInfoResponse>> getUserInfo(String headers) {
+            if (headers.equals("malformedToken")) {
+                return Mono.error(new JwtException(ExceptionMessage.JWT_MALFORMED));
+            } else {
+                return Mono.just(JsonResult.successOf(
+                        new UserInfoResponse("id", "type", "role", "name")
+                ));
+            }
+        }
+    }
+
+
+}

--- a/heachi-notify/src/test/java/com/heachi/notify/config/advice/GlobalExceptionHandlerTest.java
+++ b/heachi-notify/src/test/java/com/heachi/notify/config/advice/GlobalExceptionHandlerTest.java
@@ -1,0 +1,62 @@
+package com.heachi.notify.config.advice;
+
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.notify.TestConfig;
+import com.heachi.notify.api.controller.NotifyController;
+import com.heachi.notify.api.service.auth.AuthService;
+import com.heachi.notify.api.service.notify.NotifyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@ExtendWith(SpringExtension.class)
+@WebFluxTest(NotifyController.class)
+class GlobalExceptionHandlerTest extends TestConfig {
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private NotifyService notifyService;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    @DisplayName("Advice가 런타임에 에러가 발생하면 가져와 JsonResult.failOf()로 변환한다.")
+    void exceptionHandlerCatchException() {
+        // given
+        BDDMockito.given(authService.getUserId(anyString()))
+                .willThrow(new RuntimeException());
+
+
+        // when
+        webTestClient.get().uri("/notify/").accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .returnResult(JsonResult.class)
+                .getResponseBody()
+                // then
+                .as(StepVerifier::create)
+                .assertNext(jsonResult -> assertThat(jsonResult.getResCode()).isEqualTo(400))
+                .thenCancel()
+                .verify();
+    }
+
+}

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/ExceptionMessage.java
@@ -12,12 +12,17 @@ public enum ExceptionMessage {
     JWT_MALFORMED("올바른 JWT 토큰의 형태가 아닙니다."),
     JWT_SIGNATURE("올바른 SIGNATURE가 아닙니다."),
     JWT_ILLEGAL_ARGUMENT("잘못된 정보를 넣었습니다."),
+    JWT_USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
 
     // OAuthException
     OAUTH_INVALID_STATE("STATE 검증에 실패하였습니다."),
     OAUTH_INVALID_TOKEN_URL("tokenURL이 정확하지 않습니다."),
-    OAUTH_INVALID_ACCESS_TOKEN("잘못된 access_token 입니다.");
+    OAUTH_INVALID_ACCESS_TOKEN("잘못된 access_token 입니다."),
 
+    // AuthException
+    AUTH_SERVER_NOT_RESPOND("인증 서버가 응답하지 않습니다."),
+
+    ;
 
     private final String text;
 }

--- a/heachi-support/common/src/main/java/com/heachi/admin/common/exception/auth/AuthException.java
+++ b/heachi-support/common/src/main/java/com/heachi/admin/common/exception/auth/AuthException.java
@@ -1,0 +1,10 @@
+package com.heachi.admin.common.exception.auth;
+
+import com.heachi.admin.common.exception.ExceptionMessage;
+import com.heachi.admin.common.exception.HeachiException;
+
+public class AuthException extends HeachiException {
+    public AuthException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/heachi-support/external-clients/build.gradle
+++ b/heachi-support/external-clients/build.gradle
@@ -2,6 +2,9 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    // 내부 모듈
+    implementation project(':heachi-support:common')
+
     // Reflections 라이브러리
     implementation group: 'org.reflections', name: 'reflections', version: '0.10.2'
 

--- a/heachi-support/external-clients/src/main/java/com/heachi/external/clients/auth/AuthClients.java
+++ b/heachi-support/external-clients/src/main/java/com/heachi/external/clients/auth/AuthClients.java
@@ -1,0 +1,15 @@
+package com.heachi.external.clients.auth;
+
+import com.heachi.admin.common.response.JsonResult;
+import com.heachi.external.annotation.ExternalClients;
+import com.heachi.external.clients.auth.response.UserInfoResponse;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.GetExchange;
+import reactor.core.publisher.Mono;
+
+@ExternalClients(baseUrl = "http://localhost:8080")
+public interface AuthClients {
+
+    @GetExchange(value = "/auth/info")
+    public Mono<JsonResult<UserInfoResponse>> getUserInfo(@RequestHeader(value = "Authorization") String headers);
+}

--- a/heachi-support/external-clients/src/main/java/com/heachi/external/clients/auth/response/UserInfoResponse.java
+++ b/heachi-support/external-clients/src/main/java/com/heachi/external/clients/auth/response/UserInfoResponse.java
@@ -1,0 +1,22 @@
+package com.heachi.external.clients.auth.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class UserInfoResponse {
+    private String platformId;
+    private String platformType;
+    private String role;
+    private String name;
+
+    public UserInfoResponse(String platformId, String platformType, String role, String name) {
+        this.platformId = platformId;
+        this.platformType = platformType;
+        this.role = role;
+        this.name = name;
+    }
+}


### PR DESCRIPTION
webflux 생각보다 많이 어렵네여.. 테스트 짜는데 개고생함...

## 작업 내용

- [x] Timeout 구현 (커넥션을 맺어놓고 30초 동안 아무런 동작도 하지 않으면, 커넥션을 끊는다.)
- [x] 사용자 인증 구현 (기본 사용자 인증서버에 인증 요청을 보내, 인증된 사용자만 알림을 보낼 수 있도록 설정한다.)
- [x] blocking 코드 없애기 (code blocking을 최소화하기 위해 flatMap으로 변환)
- [x] 에러 핸들링 (에러 핸들링을 위해 RestControllerAdvice를 추가하였고, CheckedException도 RuntimeException으로 변환시켜 모든 에러를 Advice에서 다루려함.)
---
- [x] NotifyService.receive가 30초 동안 아무것도 안할때 커넥션이 끊기는지 테스트
- [x] NotifyService.receive에 커넥션이 맺어졌을때, 2초뒤 데이터가 추가됐을때 Pulling되는지 테스트

### 추가해야할 테스트
- [x] NotifyService.registNotify 테스트
- [x] AuthService에서 사용자가 이상한 토큰으로 사용자 인증을 요구할때 적절한 에러를 뱉는지 테스트
- [x] AuthService에서 인증 서버에 요청할때 인증서버 자체에 연결이 안될때 적절할 에러를 뱉는지 테스트
- [x] RestControllerAdvice에서 에러를 잘 캐치해오는지 테스트

<br/><br/>

## 리뷰 중점사항

- Reactor로 짠 코드입니다.

<br/><br/>

## 관련 이슈

#39